### PR TITLE
Update module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bradfitz/gomemcache
+module github.com/ankitkinra/gomemcache
 
 go 1.12


### PR DESCRIPTION
This has resulted in name collision which is making it difficult to use `github.com/ankitkinra/gomemcache` module with `GO111MODULE=on`